### PR TITLE
docs: fix README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ git clone https://github.com/votre-utilisateur/maduminer.git
 cd maduminer
 # Place le fichier mine.php sur ton serveur PHP (XAMPP/WAMP)
 # Lance http://localhost/maduminer/mine.php dans le navigateur
+```


### PR DESCRIPTION
## Summary
- close the bash code block at the end of README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5f88b7b4832fb9651639fadf6279